### PR TITLE
Fix br adder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=['beautifulsoup4','html5lib','regex'],
     py_modules=['lektor_mathshistory_renderer'],
     url='https://github.com/mathshistory/mathshistory-renderer',
-    version='0.4.7',
+    version='0.4.8',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',


### PR DESCRIPTION
`<br/>`s are now "cleverly" added where `\n`s were. This involves looking ahead and behind to see if the tag was a block html tag (table, tr, td, blockquote, li, etc.) and if it is, not adding it in. This usually has better results on pages like EMS index, the Darcy pages, etc., and doesn't affect other pages.